### PR TITLE
Labels auto layout mechanism

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "mocha-webpack --opts mocha-webpack.opts",
     "build": "cross-env BABEL_ENV=production webpack",
     "watch": "webpack --progress --watch",
-    "dev-server": "webpack-dev-server --open --hot --config webpack.config-dev.js",
+    "dev-server": "webpack-dev-server --host 0.0.0.0 --open --hot --config webpack.config-dev.js",
     "esdoc": "./node_modules/.bin/esdoc",
     "bootprint": "bootprint json-schema src/model/graphScheme.json docs/schema"
   },

--- a/src/components/settingsPanel.js
+++ b/src/components/settingsPanel.js
@@ -194,6 +194,10 @@ const COLORS = {
                         <h5>Layout</h5>
 
                         <div class="wrap">
+                          <mat-slide-toggle matTooltip="Toggle view mode" (change)="toggleWireView()" [checked]="config.layout.wireView === true">Show label wires</mat-slide-toggle>
+                        </div>
+
+                        <div class="wrap">
                           <mat-slide-toggle matTooltip="Toggle view mode" (change)="toggleMode()" [checked]="config.layout.numDimensions === 2">2D mode</mat-slide-toggle>
                         </div>
 
@@ -915,6 +919,7 @@ export class SettingsPanel {
     @Output() onUpdateLabels       = new EventEmitter();
     @Output() onUpdateLabelContent = new EventEmitter();
     @Output() onToggleGroup        = new EventEmitter();
+    @Output() onToggleWireView     = new EventEmitter();
     @Output() onToggleMode         = new EventEmitter();
     @Output() onToggleLayout       = new EventEmitter();
     @Output() onToggleHelperPlane  = new EventEmitter();
@@ -945,6 +950,11 @@ export class SettingsPanel {
             this.onSelectBySearch.emit(name);
         }
     }
+
+    toggleWireView(){
+      this.config.layout.wireView = ! this.config.layout.wireView ;
+      this.onToggleWireView.emit(this.config.layout.wireView);
+  }
 
     toggleMode(){
         this.config.layout.numDimensions = (this.config.layout.numDimensions === 3)? 2: 3;

--- a/src/components/webGLScene.js
+++ b/src/components/webGLScene.js
@@ -123,6 +123,7 @@ import { autoLayout, layoutLabelCollide } from '../view/render/autoLayout'
                         (onEditResource)="editResource.emit($event)"
                         (onUpdateLabels)="graph?.showLabels($event)"
                         (onToggleMode)="graph?.numDimensions($event)"
+                        (onToggleWireView)="graph?.showLabelWires($event)"
                         (onToggleLayout)="toggleLayout($event)"
                         (onToggleGroup)="toggleGroup($event)"
                         (onUpdateLabelContent)="graph?.labels($event)"
@@ -274,7 +275,8 @@ export class WebGLSceneComponent {
                 "showLayers"      : true,
                 "showLyphs3d"     : false,
                 "showCoalescences": false,
-                "numDimensions"   : 3
+                "numDimensions"   : 3,
+                "wireView"        : true
             },
             "groups": true,
             "labels": {
@@ -557,6 +559,7 @@ export class WebGLSceneComponent {
 
         this.graph.labelRelSize(this.labelRelSize);
         this.graph.showLabels(this.config["labels"]);
+        this.graph.showLabelWires(this.config["labelsWires"]);
         this.scene.add(this.graph);
 
         window.scene = this.scene ;

--- a/src/components/webGLScene.js
+++ b/src/components/webGLScene.js
@@ -24,7 +24,7 @@ require("three/examples/js/postprocessing/RenderPass");
 require("three/examples/js/postprocessing/ShaderPass");
 
 const WindowResize = require('three-window-resize');
-import { autoLayout } from '../view/render/autoLayout'
+import { autoLayout, layoutLabelCollide } from '../view/render/autoLayout'
 
 /**
  * @ignore
@@ -547,6 +547,7 @@ export class WebGLSceneComponent {
             })
             .onFinishLoading(() => {
               this.parseDefaultColors(this.getSceneObjects());
+              //layoutLabelCollide(this.scene);
             })
             .graphData(this.graphData);
 

--- a/src/models/lyphModel.js
+++ b/src/models/lyphModel.js
@@ -287,6 +287,7 @@ export class LyphModel extends Model {
             this.viewObjects['label'].visible = state.showLyphLabel;
             copyCoords(this.viewObjects['label'].position, this.center);
             this.viewObjects['label'].position.addScalar(-5);
+            this.viewObjects['label'].userData.viewPosition = this.center ;
         } else {
             delete this.viewObjects['label'];
         }

--- a/src/view/render/autoLayout.js
+++ b/src/view/render/autoLayout.js
@@ -785,7 +785,7 @@ function autoLayoutChains(scene, graphData, links){
   }
 }
 
-export function autoLayout(scene, graphData) {
+export function autoLayout(scene, graphData, showLabelWires) {
 
   let lyphs = {};
   scene.children.forEach( child => {
@@ -849,7 +849,7 @@ export function autoLayout(scene, graphData) {
   autoLayoutChains(scene, graphData, links);
   links.forEach( link => !link.modifiedChain ? removeEntity(scene, link): link.visible = false);
 
-  layoutLabelCollide(scene);
+  layoutLabelCollide(scene, showLabelWires);
 }
 
 export function clearByObjectType(scene, type) {
@@ -901,6 +901,7 @@ function checkClose(first, second)
 
 function createLineBetweenVectors(start, end)
 {
+  start.z = 0 ; //force matching plane
   const points = [];
   points.push( start );
   points.push( end );
@@ -986,7 +987,7 @@ function createLinksToOrigin(labels)
   })
 }
 //space partitioning ordering algorithm
-export function layoutLabelCollide(scene) {
+export function layoutLabelCollide(scene, showLabelWires) {
   const labels = getSceneObjectByModelClass(scene.children, "Label");
   if (labels.length > 0)
   {
@@ -999,8 +1000,8 @@ export function layoutLabelCollide(scene) {
     const spacePartitionBoxes = getSpacePartitions(spaceBox, LABEL_SPACE_PARTITION_NUM);
     for (var i = 0; i < spacePartitionBoxes.length ; i ++)
     {      
-      arrangeLabelsWithinPartition(spacePartitionBoxes[i], labels, LABEL_ELEVATION);
-      arrangeLabelsWithinPartition(spacePartitionBoxes[i], labels, LABEL_ELEVATION);
+      arrangeLabelsWithinPartition(spacePartitionBoxes[i], labels, LABEL_ELEVATION, showLabelWires);
+      //arrangeLabelsWithinPartition(spacePartitionBoxes[i], labels, LABEL_ELEVATION, showLabelWires);
       // arrangeLabelsWithinPartition(spacePartitionBoxes[i], labels, 250);
       if (DEBUG)
       {
@@ -1009,7 +1010,8 @@ export function layoutLabelCollide(scene) {
       }
     }
     removeLinePosData();
-    createLinksToOrigin(labels);
+    if (showLabelWires)
+      createLinksToOrigin(labels);
   }
 }
 

--- a/src/view/render/autoLayout.js
+++ b/src/view/render/autoLayout.js
@@ -17,6 +17,7 @@ const AXON_SIZE = 1;
 const DENDRYTE_SIZE = .5;
 const LABEL_SPACE_PARTITION_NUM = 5 ;
 const LABEL_CLOSE_ENOUGH_DISTANCE = 15.00; 
+const LABEL_ELEVATION = 50.00; 
 const DEBUG = false ;
 
 function trasverseSceneChildren(children, all) {
@@ -998,8 +999,8 @@ export function layoutLabelCollide(scene) {
     const spacePartitionBoxes = getSpacePartitions(spaceBox, LABEL_SPACE_PARTITION_NUM);
     for (var i = 0; i < spacePartitionBoxes.length ; i ++)
     {      
-      arrangeLabelsWithinPartition(spacePartitionBoxes[i], labels, 50);
-      arrangeLabelsWithinPartition(spacePartitionBoxes[i], labels, 50);
+      arrangeLabelsWithinPartition(spacePartitionBoxes[i], labels, LABEL_ELEVATION);
+      arrangeLabelsWithinPartition(spacePartitionBoxes[i], labels, LABEL_ELEVATION);
       // arrangeLabelsWithinPartition(spacePartitionBoxes[i], labels, 250);
       if (DEBUG)
       {

--- a/src/view/render/threeForceGraphKapsule.js
+++ b/src/view/render/threeForceGraphKapsule.js
@@ -186,6 +186,7 @@ export default Kapsule({
         showLyphs3d      : { default: false},
         showCoalescences : { default: false},
         showLabels       : { default: {}},
+        showLabelWires       : { default: true },
 
         labels           : { default: {Anchor: 'id', Wire: 'id', Node: 'id', Link: 'id', Lyph: 'id', Region: 'id'}},
         labelRelSize     : { default: 0.1},
@@ -333,7 +334,7 @@ export default Kapsule({
             } else { layout['tick'](); }
 
             state.graphData.updateViewObjects(state);
-            autoLayout(state.graphScene, state.graphData);
+            autoLayout(state.graphScene, state.graphData, state.showLabelWires);
         }
     }
 });

--- a/src/view/render/threeForceGraphKapsule.js
+++ b/src/view/render/threeForceGraphKapsule.js
@@ -96,6 +96,7 @@ export default Kapsule({
                             }
                             state.canvas.classList.remove('grabbable');
                             state.isPointerDragging = false;
+                            
                         })
                 );
 

--- a/src/view/render/visualResourceView.js
+++ b/src/view/render/visualResourceView.js
@@ -19,11 +19,13 @@ VisualResource.prototype.createLabels = function(){
 
     if (!this.labels[labelKey] && this[labelKey]) {
         this.labels[labelKey] = new SpriteText2D(this[labelKey], this.state.fontParams);
+        this.labels[labelKey].userData = { class: 'Label'}
         this.labels[labelKey].material.alphaTest = 0.1
     }
 
     if (this.labels[labelKey]){
         this.viewObjects["label"] = this.labels[labelKey];
+        this.labels[labelKey].userData = { class: 'Label'}
         this.viewObjects["label"].visible = !this.hidden;
     } else {
         delete this.viewObjects["label"];

--- a/src/view/render/visualResourceView.js
+++ b/src/view/render/visualResourceView.js
@@ -44,6 +44,7 @@ VisualResource.prototype.updateLabels = function(position){
         if (this.labels[labelKey].visible) {
             this.labels[labelKey].scale.set(this.state.labelRelSize, this.state.labelRelSize, this.state.labelRelSize);
             copyCoords(this.labels[labelKey].position, position);
+            this.labels[labelKey].userData.viewPosition = position ;
             this.viewObjects['label'] = this.labels[labelKey];
         }
     } else {


### PR DESCRIPTION
- A divide and conquer collision detection algorithm has been implemented.
- Collision detection seems the natural thing to do here
- Divide and conquer type,  because we don't want to evaluate everything against everything (as this would require quadratic time and resources)

How does it work?

- First, compute all the known space where labels are placed (This won't necessary match the TOO map known space)
- Divide that space in in NxM subspaces, where  N and M are given.
- for each subspace(N,M), do collision detection withing the labels contained by that space
- "Explode" the labels which collide. Exploding is moving them away from the origin in all the directions (x,y,z)
- create a reference line joining the final position to the original position

![Screenshot 2022-01-12 123431](https://user-images.githubusercontent.com/5366927/149188983-52d954ba-3b6b-419c-b152-2bb74c92b999.png)
