### PR TITLE
Feature/116 - Remove auto layout links and add back nodes.

### DIFF
--- a/src/view/render/autoLayout.js
+++ b/src/view/render/autoLayout.js
@@ -211,7 +211,7 @@ function layoutLyphs(scene, hostLyphDic, lyphDic, lyphInLyph)
   let kapsuleChildren = scene.children ;
   trasverseSceneChildren(kapsuleChildren, all);
   let lyphs = getSceneObjectByModelClass(all, 'Lyph');
-  // clearByObjectType(scene, 'Node');
+  //clearByObjectType(scene, 'Node');
   Object.keys(hostLyphDic).forEach((hostKey) => {
     //get target aspect ratio
     const host = getHostParentForLyph(all, hostKey) ;
@@ -408,7 +408,7 @@ export function autoLayout(scene, graphData) {
   });
 
   preventZFighting(scene);
-  // clearByObjectType(scene, "Node");
+  //clearByObjectType(scene, "Node");
   let hostLyphRegionDic = {}, lyphDic = {};
   trasverseHostedBy(graphData, hostLyphRegionDic);
   layoutLyphs(scene, hostLyphRegionDic, lyphDic, false);
@@ -461,6 +461,7 @@ export function autoLayout(scene, graphData) {
     }
   });
   
-  // autoLayoutChains(scene, graphData, links);
-  // links.forEach( link => !link.modifiedChain ? removeEntity(scene, link): link.visible = false);
+  //FIXME : Fix chians with nodes
+  //autoLayoutChains(scene, graphData, links);
+  //links.forEach( link => !link.modifiedChain ? removeEntity(scene, link): link.visible = false);
 }

--- a/src/view/render/autoLayout.js
+++ b/src/view/render/autoLayout.js
@@ -211,7 +211,7 @@ function layoutLyphs(scene, hostLyphDic, lyphDic, lyphInLyph)
   let kapsuleChildren = scene.children ;
   trasverseSceneChildren(kapsuleChildren, all);
   let lyphs = getSceneObjectByModelClass(all, 'Lyph');
-  clearByObjectType(scene, 'Node');
+  // clearByObjectType(scene, 'Node');
   Object.keys(hostLyphDic).forEach((hostKey) => {
     //get target aspect ratio
     const host = getHostParentForLyph(all, hostKey) ;
@@ -408,7 +408,7 @@ export function autoLayout(scene, graphData) {
   });
 
   preventZFighting(scene);
-  clearByObjectType(scene, "Node");
+  // clearByObjectType(scene, "Node");
   let hostLyphRegionDic = {}, lyphDic = {};
   trasverseHostedBy(graphData, hostLyphRegionDic);
   layoutLyphs(scene, hostLyphRegionDic, lyphDic, false);
@@ -461,6 +461,6 @@ export function autoLayout(scene, graphData) {
     }
   });
   
-  //autoLayoutChains(scene, graphData, links);
-  //links.forEach( link => !link.modifiedChain ? removeEntity(scene, link): link.visible = false);
+  // autoLayoutChains(scene, graphData, links);
+  // links.forEach( link => !link.modifiedChain ? removeEntity(scene, link): link.visible = false);
 }


### PR DESCRIPTION
@enicolasgomez I added back the nodes and removed our own chains from the auto layout. In order to use the auto-layout chains, we need a bit more work on it this week, which will slow down the merge.

What do you think about merging with these changes only? Once we have the nodes working with the chains from the auto-layout, we can do a separate merge.


For now, this is how it looks with nodes on it, the nodes are visible again on the wires. 
![Screenshot from 2022-04-04 07-07-10](https://user-images.githubusercontent.com/4562825/161563428-c2865a74-f71f-4449-8ab9-a8d3804a29ce.png)
![Screenshot from 2022-04-04 07-06-56](https://user-images.githubusercontent.com/4562825/161563432-28e59604-e1f3-41c0-9e60-514d9682fd5c.png)
