### PR TITLE
Git actions/176

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,3 +34,24 @@ jobs:
           npm run snapshot_test
       env:
           CI: true
+jobs: 
+  keast-spinal_test:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-20.04
+    container: lironavon/docker-puppeteer-container:14.16.0
+    env:
+      CI: true
+    steps:
+    - uses: actions/checkout@v1
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+          node-version: ${{ matrix.node-version }}
+    - name: keast spinal model snapshot test
+      run: |
+          #install dependencies
+          npm ci
+          # run element snapshot tests
+          npm run keast_snapshot_test
+      env:
+          CI: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,6 @@ jobs:
           npm run snapshot_test
       env:
           CI: true
-jobs: 
   keast-spinal_test:
     # The type of runner that the job will run on
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Added Keast Spinal Model tests to run with GitHub actions alongside the too-map tests, upon creating a pull request or merging to `develop` and `master` branch